### PR TITLE
chore(workflow): update checkout action and token usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN_GITHUB }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -40,9 +42,9 @@ jobs:
       - test
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CI_GITHUB_PAT }}
+          token: ${{ secrets.TOKEN_GITHUB }}
           persist-credentials: true
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN_GITHUB }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2


### PR DESCRIPTION
Upgrade the checkout action from v2 to v4 in build.yml and test.yml for improved performance and security. Replace the token used in the checkout steps to use `TOKEN_GITHUB` for consistency and better secret management.