### PR TITLE
feat(firebase): add local role validation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ import { FirebaseAuthGuard } from '@alpha018/nestjs-firebase-auth';
               extractor: ExtractJwt.fromAuthHeaderAsBearerToken(), // Choose your extractor from the Passport library
               checkRevoked: true, // Set to true if you want to check for revoked Firebase tokens
               validateRole: true, // Set to true if you want to validate user roles
+              useLocalRoles: true, // Set to true if you want to validate user roles locally without firebase call
             },
           },
         }),
@@ -63,13 +64,14 @@ import { FirebaseAuthGuard } from '@alpha018/nestjs-firebase-auth';
 ```
 ## Parameter Options
 
-| Parameter                      | Type         | Required | Description                                                                                         |
-|--------------------------------|--------------|----------|-----------------------------------------------------------------------------------------------------|
-| `base64`                       | `string`     | Yes*     | Base64 encoded service account JSON string. Required if `options` is not provided.                  |
-| `options`                      | `object`     | Yes*     | Firebase Admin SDK configuration options. Required if `base64` is not provided.                     |
-| `auth.config.extractor`        | `function`   | Optional | A custom extractor function from the Passport library to extract the token from the request.        |
-| `auth.config.checkRevoked`     | `boolean`    | Optional | Set to `true` to check if the Firebase token has been revoked. Defaults to `false`.                 |
-| `auth.config.validateRole`     | `boolean`    | Optional | Set to `true` to validate user roles using Firebase custom claims. Defaults to `false`.             |
+| Parameter                   | Type       | Required | Description                                                                                                                                                                                                               |
+|-----------------------------|------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `base64`                    | `string`   | Yes*     | Base64 encoded service account JSON string. Required if `options` is not provided.                                                                                                                                        |
+| `options`                   | `object`   | Yes*     | Firebase Admin SDK configuration options. Required if `base64` is not provided.                                                                                                                                           |
+| `auth.config.extractor`     | `function` | Optional | A custom extractor function from the Passport library to extract the token from the request.                                                                                                                              |
+| `auth.config.checkRevoked`  | `boolean`  | Optional | Set to `true` to check if the Firebase token has been revoked. Defaults to `false`.                                                                                                                                       |
+| `auth.config.validateRole`  | `boolean`  | Optional | Set to `true` to validate user roles using Firebase custom claims. Defaults to `false`.                                                                                                                                   |
+| `auth.config.useLocalRoles` | `boolean`  | Optional | Set to `true` to validate user roles using local custom claims inside the JWT token. Defaults to `false`. **Note:** If you update the claims, previously issued tokens may still contain outdated roles and remain valid. |
 
 
 ### Auth Guard Without Role Validation

--- a/src/firebase/__mocks__/firebase-user-mock.ts
+++ b/src/firebase/__mocks__/firebase-user-mock.ts
@@ -1,0 +1,18 @@
+export const userDecode = {
+  roles: ['admin'],
+  iss: 'https://securetoken.google.com/project-test-123',
+  aud: 'project-test-123',
+  auth_time: 1111111111,
+  user_id: 'super-user-id-mock-test',
+  sub: 'super-sub-mock-test',
+  iat: 1111111111,
+  exp: 1111111111,
+  email: 'test@test.com',
+  email_verified: false,
+  firebase: {
+    identities: {
+      email: ['test@test.com'],
+    },
+    sign_in_provider: 'custom',
+  },
+};

--- a/src/firebase/guard/firebase.guard.ts
+++ b/src/firebase/guard/firebase.guard.ts
@@ -55,7 +55,10 @@ export class FirebaseGuard implements CanActivate {
       return true;
     }
 
-    const claims = await this.firebaseProvider.getClaimsRoleBase(decodedToken.uid);
+    const claims = await this.firebaseProvider.getClaimsRoleBase(
+      decodedToken,
+      this.config.auth?.config?.useLocalRoles || false,
+    );
 
     request['metadata'] = {
       ...request['metadata'],

--- a/src/firebase/interface/options.interface.ts
+++ b/src/firebase/interface/options.interface.ts
@@ -4,4 +4,5 @@ export interface FirebaseAuthStrategyOptions {
   extractor?: JwtFromRequestFunction;
   checkRevoked?: boolean;
   validateRole?: boolean;
+  useLocalRoles?: boolean;
 }

--- a/src/firebase/provider/firebase.provider.spec.ts
+++ b/src/firebase/provider/firebase.provider.spec.ts
@@ -4,6 +4,8 @@ import { FirebaseProvider } from './firebase.provider';
 import { FirebaseConstructorInterface } from '../interface/firebase-constructor.interface';
 import { getAuth } from 'firebase-admin/auth';
 import * as fa from 'firebase-admin';
+import { userDecode } from '../__mocks__/firebase-user-mock';
+import { DecodedIdToken } from 'firebase-admin/lib/auth';
 
 jest.mock('firebase-admin/app', () => ({
   initializeApp: jest.fn(),
@@ -117,24 +119,31 @@ describe('FirebaseProvider', () => {
 
   describe('getClaimsRoleBase', () => {
     it('should get custom user claims', async () => {
-      const uid = 'test-uid';
+      const user = userDecode as any as DecodedIdToken;
       const claims = ['admin'];
       mockAuth.getUser.mockResolvedValue({
         customClaims: { roles: claims },
       });
 
-      const result = await provider.getClaimsRoleBase(uid);
+      const result = await provider.getClaimsRoleBase(user, true);
       expect(result).toEqual(claims);
+
+      const localResult = await provider.getClaimsRoleBase(user, false);
+      expect(localResult).toEqual(claims);
     });
 
     it('should return undefined if no custom claims', async () => {
-      const uid = 'test-uid';
+      const user = userDecode as any as DecodedIdToken;
+      user.roles = undefined;
       mockAuth.getUser.mockResolvedValue({
         customClaims: undefined,
       });
 
-      const result = await provider.getClaimsRoleBase(uid);
+      const result = await provider.getClaimsRoleBase(user, true);
       expect(result).toBeUndefined();
+
+      const localResult = await provider.getClaimsRoleBase(user, false);
+      expect(localResult).toBeUndefined();
     });
   });
 });

--- a/src/firebase/provider/firebase.provider.ts
+++ b/src/firebase/provider/firebase.provider.ts
@@ -3,6 +3,7 @@ import { initializeApp, getApps, getApp, App } from 'firebase-admin/app';
 import { FirebaseConstructorInterface } from '../interface/firebase-constructor.interface';
 import { getAuth } from 'firebase-admin/auth';
 import * as fa from 'firebase-admin';
+import { DecodedIdToken } from 'firebase-admin/lib/auth';
 
 @Injectable()
 export class FirebaseProvider {
@@ -35,8 +36,12 @@ export class FirebaseProvider {
     });
   }
 
-  async getClaimsRoleBase<T>(uid: string): Promise<T[] | undefined> {
-    const user = await this.auth.getUser(uid);
-    return user.customClaims ? (user.customClaims['roles'] as T[]) : undefined;
+  async getClaimsRoleBase<T>(user: DecodedIdToken, localDecode: boolean): Promise<T[] | undefined> {
+    if (localDecode) {
+      return user.roles;
+    }
+
+    const { customClaims } = await this.auth.getUser(user.uid);
+    return customClaims?.roles;
   }
 }

--- a/test/app-local-validation.e2e-spec.ts
+++ b/test/app-local-validation.e2e-spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { Roles, UsersController } from './controller/user.controller';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { FirebaseAdminModule } from '../src';
+import { ExtractJwt } from 'passport-jwt';
+import * as firebase from 'firebase/app';
+import { signInWithCustomToken, getAuth } from 'firebase/auth';
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication;
+  let configService: ConfigService;
+  let server: any;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+        }),
+        FirebaseAdminModule.forRootAsync({
+          imports: [ConfigModule],
+          useFactory: (configService: ConfigService) => ({
+            base64: configService.get('FIREBASE_SERVICE_ACCOUNT_BASE64'),
+            auth: {
+              config: {
+                extractor: ExtractJwt.fromAuthHeaderAsBearerToken(),
+                validateRole: true,
+                useLocalRoles: true,
+              },
+            },
+          }),
+          inject: [ConfigService],
+        }),
+      ],
+      controllers: [UsersController],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    server = app.getHttpServer();
+    configService = app.get(ConfigService);
+
+    const firebaseConfig = JSON.parse(
+      Buffer.from(configService.get<string>('FIREBASE_CLIENT_BASE64'), 'base64').toString('utf-8'),
+    );
+
+    if (!firebase.getApps().length) {
+      firebase.initializeApp(firebaseConfig);
+    }
+  });
+
+  const loginAndGetIdToken = async (uid: string) => {
+    const customTokenResponse = await request(app.getHttpServer())
+      .post('/users/login')
+      .send({ uid });
+    const { accessToken } = customTokenResponse.body;
+    const auth = getAuth();
+    const userCredential = await signInWithCustomToken(auth, accessToken);
+    return userCredential.user.getIdToken();
+  };
+
+  it('/users/me (GET - Forbidden)', async () => {
+    await request(app.getHttpServer()).get('/users/me').expect(403);
+  });
+
+  it('/users/login (POST - Ok)', async () => {
+    const uid = configService.get('FIREBASE_TEST_USER');
+    const result = await request(app.getHttpServer()).post('/users/login').send({ uid });
+
+    const responseBody = result.body;
+    expect(result.status).toBe(200);
+    expect(responseBody).toHaveProperty('accessToken');
+    const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/;
+    expect(responseBody.accessToken).toMatch(jwtRegex);
+  });
+
+  it('/users/me (POST - Login - Me)', async () => {
+    const uid = configService.get('FIREBASE_TEST_USER');
+    const idToken = await loginAndGetIdToken(uid);
+
+    const result = await request(app.getHttpServer())
+      .get('/users/me')
+      .set('Authorization', `Bearer ${idToken}`)
+      .expect(200);
+
+    const responseBody = result.body;
+    expect(responseBody).toHaveProperty('user');
+    expect(responseBody.user).toHaveProperty('aud');
+    expect(responseBody.user).toHaveProperty('user_id');
+    expect(typeof responseBody.user.user_id).toBe('string');
+    expect(responseBody.user).toHaveProperty('email');
+    expect(typeof responseBody.user.email).toBe('string');
+    expect(responseBody.user).toHaveProperty('firebase');
+    expect(responseBody.user.firebase).toHaveProperty('sign_in_provider');
+  });
+
+  it('/users/set-claims (POST - Set claims)', async () => {
+    const uid = configService.get('FIREBASE_TEST_USER');
+    const response = await request(app.getHttpServer())
+      .post('/users/set-claims')
+      .send({ uid, claim: Roles.ADMIN })
+      .expect(200);
+
+    const responseBody = response.body;
+    expect(responseBody).toHaveProperty('status');
+  });
+
+  it('/users/get-claims (GET - Get claims)', async () => {
+    const uid = configService.get('FIREBASE_TEST_USER');
+    const idToken = await loginAndGetIdToken(uid);
+
+    const response = await request(app.getHttpServer())
+      .get('/users/get-claims')
+      .set('Authorization', `Bearer ${idToken}`)
+      .expect(200);
+
+    const responseBody = response.body;
+    expect(responseBody).toHaveProperty('claims', [Roles.ADMIN]);
+  });
+
+  it('/users/get-claims (GET - Get claims - 401)', async () => {
+    const uid = configService.get('FIREBASE_TEST_USER');
+    let idToken = await loginAndGetIdToken(uid);
+
+    await request(app.getHttpServer())
+      .post('/users/set-claims')
+      .send({ uid, claim: Roles.USER })
+      .expect(200);
+
+    // refresh local token
+    idToken = await loginAndGetIdToken(uid);
+    const response = await request(app.getHttpServer())
+      .get('/users/get-claims')
+      .set('Authorization', `Bearer ${idToken}`)
+      .expect(403);
+
+    const responseBody = response.body;
+    expect(responseBody).toHaveProperty('statusCode', 403);
+  });
+
+  afterAll(async () => {
+    const uid = configService.get('FIREBASE_TEST_USER');
+    await request(app.getHttpServer()).post('/users/set-claims').send({ uid, claim: null });
+    await app.close();
+    server.close();
+  });
+});


### PR DESCRIPTION
Introduce the `useLocalRoles` option for Firebase authentication configuration, allowing user roles to be validated using locally decoded JWT tokens without making a call to Firebase.

- Modify `FirebaseProvider.getClaimsRoleBase()` to accept a `DecodedIdToken` and a `localDecode` parameter to determine method of role extraction.
- Update test cases in `firebase.provider.spec.ts` to accommodate changes in role validation.
- Add `useLocalRoles` as an optional parameter in `options.interface.ts`.
- Update README.md to document the new `useLocalRoles` configuration option.
- Ensure `FirebaseGuard` utilizes the new role validation logic.
- Add `firebase-user-mock.ts` for mock user data testing.
- Implement `app-local-validation.e2e-spec.ts` end-to-end tests for local role validation.