### PR TITLE
feat(workflows): remove Node.js 18.x from test and build matrix and f…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x ]
     env:
       FIREBASE_TEST_USER: ${{ secrets.FIREBASE_TEST_USER }}
       FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x ]
     env:
       FIREBASE_TEST_USER: ${{ secrets.FIREBASE_TEST_USER }}
       FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}

--- a/release.config.js
+++ b/release.config.js
@@ -1,7 +1,6 @@
 const isDryRun = process.argv.includes('--dry-run');
 
 module.exports = {
-  branches: [{ name: 'main' }],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
@@ -21,10 +20,11 @@ module.exports = {
     [
       '@semantic-release/git',
       {
-        assets: ['package.json', 'docs/CHANGELOG.md'],
         message: 'chore(release): ${nextRelease.version} [skip ci]',
+        assets: ['package.json', 'docs/CHANGELOG.md'],
       },
     ],
     ...(isDryRun ? [] : ['@semantic-release/github']),
   ],
+  branches: [{ name: 'main' }],
 };


### PR DESCRIPTION
…orce release

Remove support for Node.js version 18.x from the test and build workflows. This ensures the workflows
only run with Node.js versions 20.x and 22.x, simplifying the maintenance and aligning with current support strategies.