### PR TITLE
fix(scripts): simplify postinstall script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "postinstall": "[ -d '.husky' ] && husky install || true"
+    "postinstall": "husky || true"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.5",


### PR DESCRIPTION
Simplify the "postinstall" script by directly invoking "husky" without checking the directory. This change ensures that the script runs more efficiently.