### PR TITLE
fix(workflow): add FIREBASE_TEST_USER_LOCAL environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
         node-version: [ 20.x, 22.x ]
     env:
       FIREBASE_TEST_USER: ${{ secrets.FIREBASE_TEST_USER }}
+      FIREBASE_TEST_USER_LOCAL: ${{ secrets.FIREBASE_TEST_USER_LOCAL }}
       FIREBASE_SERVICE_ACCOUNT_BASE64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}
       FIREBASE_CLIENT_BASE64: ${{ secrets.FIREBASE_CLIENT_BASE64 }}
 


### PR DESCRIPTION
Include the FIREBASE_TEST_USER_LOCAL environment variable in the GitHub Actions workflow. This change
ensures that the local test user configuration is accounted for during the build process, enhancing the flexibility of our CI/CD pipeline.